### PR TITLE
Reduce image size

### DIFF
--- a/library/src/main/java/com/steelkiwi/cropiwa/config/CropIwaSaveConfig.java
+++ b/library/src/main/java/com/steelkiwi/cropiwa/config/CropIwaSaveConfig.java
@@ -73,6 +73,16 @@ public class CropIwaSaveConfig {
             return this;
         }
 
+        public Builder setHeight(int height) {
+            saveConfig.height = height;
+            return this;
+        }
+
+        public Builder setWidth(int width) {
+            saveConfig.width = width;
+            return this;
+        }
+
         public CropIwaSaveConfig build() {
             return saveConfig;
         }

--- a/library/src/main/java/com/steelkiwi/cropiwa/image/CropIwaBitmapManager.java
+++ b/library/src/main/java/com/steelkiwi/cropiwa/image/CropIwaBitmapManager.java
@@ -186,6 +186,7 @@ public class CropIwaBitmapManager {
             return getOptimalSizeOptions(c, uri, width, height);
         } else {
             BitmapFactory.Options options = new BitmapFactory.Options();
+            options.inPreferredConfig = Bitmap.Config.RGB_565;
             options.inSampleSize = 1;
             return options;
         }
@@ -195,11 +196,16 @@ public class CropIwaBitmapManager {
             Context context, Uri bitmapUri,
             int reqWidth, int reqHeight) throws FileNotFoundException {
         InputStream is = context.getContentResolver().openInputStream(bitmapUri);
+
         BitmapFactory.Options result = new BitmapFactory.Options();
+        result.inPreferredConfig = Bitmap.Config.RGB_565;
         result.inJustDecodeBounds = true;
+
         BitmapFactory.decodeStream(is, null, result);
+
         result.inJustDecodeBounds = false;
         result.inSampleSize = calculateInSampleSize(result, reqWidth, reqHeight);
+
         return result;
     }
 

--- a/library/src/main/java/com/steelkiwi/cropiwa/image/CropIwaBitmapManager.java
+++ b/library/src/main/java/com/steelkiwi/cropiwa/image/CropIwaBitmapManager.java
@@ -26,7 +26,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.steelkiwi.cropiwa.util.CropIwaUtils.*;
+import static com.steelkiwi.cropiwa.util.CropIwaUtils.closeSilently;
 
 /**
  * @author Yaroslav Polyakov https://github.com/polyak01
@@ -210,13 +210,12 @@ public class CropIwaBitmapManager {
     }
 
     private static int calculateInSampleSize(BitmapFactory.Options options, int reqWidth, int reqHeight) {
-        final int height = options.outHeight;
-        final int width = options.outWidth;
+        final int bitmapHeight = options.outHeight;
+        final int bitmapWidth = options.outWidth;
         int inSampleSize = 1;
-        if (height > reqHeight || width > reqWidth) {
-            final int halfHeight = height / 2;
-            final int halfWidth = width / 2;
-            while ((halfHeight / inSampleSize) >= reqHeight && (halfWidth / inSampleSize) >= reqWidth) {
+        if (bitmapHeight > reqHeight || bitmapWidth > reqWidth) {
+            while ((bitmapHeight / inSampleSize) >= reqHeight
+                    && (bitmapWidth / inSampleSize) >= reqWidth) {
                 inSampleSize *= 2;
             }
         }


### PR DESCRIPTION
We are experiencing OOMs with this library. I changed ARGB_8888 to RGB_565, this will use 2 bytes per pixel instead of 4. 
When cropping an image the height and width were always -1. Which means that it will use the current size of the bitmap. So from now on we can set the max height and width. `calculateInSampleSize()` will down size it until it's smaller than the requested size.

I cropping a 5.08 MB image with the old and the new solution:
old way: 55005808 bytes
new way: 428904 bytes

